### PR TITLE
Cria página com 5 usuários mais ativos do github

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { SearchRepoComponent } from './views/search-repo/search-repo.component';
 import { SearchesComponent } from './components/searches/searches.component';
 import { FormsModule } from '@angular/forms';
 import { UserComponent } from './views/user/user.component';
+import { RankingUsersComponent } from './components/ranking-users/ranking-users.component';
 
 @NgModule({
   declarations: [
@@ -28,7 +29,8 @@ import { UserComponent } from './views/user/user.component';
     LastSearchesComponent,
     SearchRepoComponent,
     SearchesComponent,
-    UserComponent
+    UserComponent,
+    RankingUsersComponent
   ],
   imports: [
     AppRoutingModule,

--- a/src/app/components/active-users/active-users.component.html
+++ b/src/app/components/active-users/active-users.component.html
@@ -1,0 +1,1 @@
+<p>active-users works!</p>

--- a/src/app/components/active-users/active-users.component.ts
+++ b/src/app/components/active-users/active-users.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-active-users',
+  templateUrl: './active-users.component.html',
+  styleUrls: ['./active-users.component.scss']
+})
+export class ActiveUsersComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/components/active-users/active-users.service.ts
+++ b/src/app/components/active-users/active-users.service.ts
@@ -1,0 +1,28 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Users } from '../searches/user/users.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ActiveUsersService {
+  baseUrl = 'http://api.github.com';
+
+  constructor(private http: HttpClient) {}
+
+  getUsers({
+    query,
+    per_page = '5'
+  }: {
+    query: string;
+    per_page?: string;
+  }): Observable<Users> {
+    const url = `${this.baseUrl}/search/users`;
+    let params = new HttpParams();
+    params = params.append('q', query);
+    params = params.append('per_page', per_page);
+
+    return this.http.get<Users>(url, { params });
+  }
+}

--- a/src/app/components/ranking-users/ranking-users.component.html
+++ b/src/app/components/ranking-users/ranking-users.component.html
@@ -3,7 +3,7 @@
 <div class="row">
   <mdb-card
     [routerLink]="['/usuario/' + user.login]"
-    class="col overlay zoom"
+    class="col-sm overlay zoom"
     *ngFor="let user of users.items; let i = index"
   >
     <div class="view rgba-white-slight waves-light" mdbWavesEffect>

--- a/src/app/components/ranking-users/ranking-users.component.html
+++ b/src/app/components/ranking-users/ranking-users.component.html
@@ -1,1 +1,26 @@
-<p>ranking-users works!</p>
+<!-- Card -->
+
+<div class="row">
+  <mdb-card
+    [routerLink]="['/usuario/' + user.login]"
+    class="col overlay zoom"
+    *ngFor="let user of users.items; let i = index"
+  >
+    <div class="view rgba-white-slight waves-light" mdbWavesEffect>
+      <!-- Card img -->
+      <mdb-card-img [src]="user.avatar_url" alt="Card image cap"></mdb-card-img>
+      <a>
+        <div class="mask"></div>
+      </a>
+    </div>
+    <!--Card content-->
+    <mdb-card-body>
+      <mdb-card-title>
+        <strong>{{ i + 1 }}º</strong>
+        <br />
+        @{{ user.login }}</mdb-card-title
+      >
+    </mdb-card-body>
+  </mdb-card>
+  <!-- Card -->
+</div>

--- a/src/app/components/ranking-users/ranking-users.component.html
+++ b/src/app/components/ranking-users/ranking-users.component.html
@@ -1,0 +1,1 @@
+<p>ranking-users works!</p>

--- a/src/app/components/ranking-users/ranking-users.component.scss
+++ b/src/app/components/ranking-users/ranking-users.component.scss
@@ -1,0 +1,14 @@
+.card {
+  width: 300px;
+  margin: 20px 5px;
+}
+
+.view {
+  border-radius: 50%;
+  width: 100px;
+  margin: 20px auto;
+}
+
+.row {
+  margin-top: 60px;
+}

--- a/src/app/components/ranking-users/ranking-users.component.scss
+++ b/src/app/components/ranking-users/ranking-users.component.scss
@@ -14,3 +14,15 @@
 .row {
   margin-top: 60px;
 }
+
+@media (max-width: 500px) {
+  .card {
+    width: 200px;
+    margin: 0 auto;
+    margin-top: 20px;
+  }
+
+  .row {
+    margin: 20px 0;
+  }
+}

--- a/src/app/components/ranking-users/ranking-users.component.scss
+++ b/src/app/components/ranking-users/ranking-users.component.scss
@@ -1,12 +1,14 @@
 .card {
   width: 300px;
   margin: 20px 5px;
+  border: 1px solid #c2c2c2 !important;
 }
 
 .view {
   border-radius: 50%;
   width: 100px;
-  margin: 20px auto;
+  margin: 0 auto;
+  margin-top: 20px;
 }
 
 .row {

--- a/src/app/components/ranking-users/ranking-users.component.ts
+++ b/src/app/components/ranking-users/ranking-users.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { Users } from '../searches/user/users.model';
+import { RankingUsersService } from './ranking-users.service';
+
+@Component({
+  selector: 'app-ranking-users',
+  templateUrl: './ranking-users.component.html',
+  styleUrls: ['./ranking-users.component.scss']
+})
+export class RankingUsersComponent implements OnInit {
+  users: Users;
+  query = 'location:brazil+location:brazil';
+  constructor(private services: RankingUsersService) {}
+
+  ngOnInit(): void {
+    this.services.getUsers({ query: this.query }).subscribe((users: Users) => {
+      this.users = users;
+      console.log(users);
+      // this.rowData = this.users.items;
+    });
+  }
+}

--- a/src/app/components/ranking-users/ranking-users.component.ts
+++ b/src/app/components/ranking-users/ranking-users.component.ts
@@ -15,7 +15,6 @@ export class RankingUsersComponent implements OnInit {
   ngOnInit(): void {
     this.services.getUsers({ query: this.query }).subscribe((users: Users) => {
       this.users = users;
-      console.log(users);
     });
   }
 }

--- a/src/app/components/ranking-users/ranking-users.component.ts
+++ b/src/app/components/ranking-users/ranking-users.component.ts
@@ -16,7 +16,6 @@ export class RankingUsersComponent implements OnInit {
     this.services.getUsers({ query: this.query }).subscribe((users: Users) => {
       this.users = users;
       console.log(users);
-      // this.rowData = this.users.items;
     });
   }
 }

--- a/src/app/components/ranking-users/ranking-users.service.ts
+++ b/src/app/components/ranking-users/ranking-users.service.ts
@@ -1,0 +1,28 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Users } from '../searches/user/users.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RankingUsersService {
+  baseUrl = 'http://api.github.com';
+
+  constructor(private http: HttpClient) {}
+
+  getUsers({
+    query,
+    per_page = '5'
+  }: {
+    query: string;
+    per_page?: string;
+  }): Observable<Users> {
+    const url = `${this.baseUrl}/search/users`;
+    let params = new HttpParams();
+    params = params.append('q', query);
+    params = params.append('per_page', per_page);
+
+    return this.http.get<Users>(url, { params });
+  }
+}

--- a/src/app/components/searches/searches.service.ts
+++ b/src/app/components/searches/searches.service.ts
@@ -9,8 +9,9 @@ import { Users } from './user/users.model';
   providedIn: 'root'
 })
 export class SearchesService {
-  constructor(private http: HttpClient) {}
   baseUrl = 'http://api.github.com';
+
+  constructor(private http: HttpClient) {}
 
   getUsers({
     query,

--- a/src/app/views/active-users/active-users.component.html
+++ b/src/app/views/active-users/active-users.component.html
@@ -1,3 +1,4 @@
 <section class="container">
   <h1>Usuários mais ativos</h1>
+  <app-ranking-users></app-ranking-users>
 </section>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -37,6 +37,7 @@ body {
   margin: 0 auto;
   min-height: 100vh;
   padding: 4rem 0;
+  text-align: center;
 }
 
 .selected {


### PR DESCRIPTION
Closes #4

----

Com relação a issue #9 
De acordo como que eu achei na documentação da API, o github, por padrão, sempre retorna uma lista de objetos ordenados por rank em ordem decrescente o que eles chamam de ["best match"](https://docs.github.com/en/free-pro-team@latest/rest/reference/search#search-users--parameters). Implementei uma busca de acordo com o local desses usuários, no caso usuários mais ativos do Brasil.